### PR TITLE
Add link to presented slides

### DIFF
--- a/source/events/2016-05-25-s02e08.html.erb
+++ b/source/events/2016-05-25-s02e08.html.erb
@@ -6,6 +6,7 @@ participants_count: 32
 talks:
   - subject: "Learn To Learn: facts about learning"
     speaker: Rémi Emonet
+    slides_url: https://github.com/twitwi/Presentation-2016-05-25-learntolearn-webenvert/
   - subject: Comment ça se passe quand je Googlise ?
     speaker: Nicolas Montes
   - subject: Containers, VMs, Processes… Isolation, performances, I/O… Comment ces technologies fonctionnent et comment les différencier ?


### PR DESCRIPTION

Untested as my ruby seems too old.
(Gem::InstallError: listen requires Ruby version >= 2.2.3, ~> 2.2.)
