### PR TITLE
manually add year to next event

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -9,7 +9,7 @@
   <div class="container">
     <h3>Prochain épisode : S06E01 🍻</h3>
     <div class="event-details">
-      <p><%= image_tag 'calendar.svg' %> Mercredi 13 octobre de 19h à 22h <span class="separator">|</span> <%= image_tag 'map_marker.svg' %> Grinta - 19 rue Georges Dupré</p>
+      <p><%= image_tag 'calendar.svg' %> Mercredi 13 octobre 2021 de 19h à 22h <span class="separator">|</span> <%= image_tag 'map_marker.svg' %> Grinta - 19 rue Georges Dupré</p>
     </div>
 
     <div class="event-talks">


### PR DESCRIPTION
Clarify that the "next event" actually happened last year.

It's a stop-gap but I'm fearful that transforming next-episode to last-episode would be understood as last-episode-ever which it definitely isn't.